### PR TITLE
Fix the typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ pandas
 
 csv
 
-imblearn# cmpt459
+imblearn
 # cmpt459


### PR DESCRIPTION
Duplicate word description
Just delete the first "# cmpt459" after "imblearn"